### PR TITLE
fix licence id

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 authors = ["OpenZeppelin"]
 edition = "2024"
-license = "APGL-3.0"
+license = "AGPL-3.0-only"
 repository = "https://github.com/OpenZeppelin/Event-Scanner"
 version = "0.1.0-alpha.1"
 


### PR DESCRIPTION
According to [official cargo book](https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields), the license ID must be one from this list: https://github.com/spdx/license-list-data/blob/v3.20/text/AGPL-3.0-only.txt

And of course there was also a typo in the original value