### PR TITLE
Remove TODO Comments + Remove Unused `retry_interval` field

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ async fn run_scanner(ws_url: alloy::transports::http::reqwest::Url, contract: al
 - `with_callback_strategy(strategy)` – override retry behaviour (`StateSyncAwareStrategy` by default).
 - `with_blocks_read_per_epoch` - how many blocks are read at a time in a single batch (taken into consideration when fetching historical blocks)
 - `with_reorg_rewind_depth` - how many blocks to rewind when a reorg is detected
-- `with_retry_interval` - how often to retry failed callbacks
 - `with_block_confirmations` - how many confirmations to wait for before considering a block final
 
 Once configured, connect using either `connect_ws::<Ethereum>(ws_url)` or `connect_ipc::<Ethereum>(path)`. This will `build` the `EventScanner` and allow you to call run to start in various [modes](#scanning-Modes).

--- a/src/event_scanner.rs
+++ b/src/event_scanner.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc};
 
 use crate::{
     block_range_scanner::{self, BlockRangeScanner, ConnectedBlockRangeScanner},
@@ -74,13 +74,6 @@ impl EventScannerBuilder {
     pub fn with_reorg_rewind_depth(mut self, reorg_rewind_depth: u64) -> Self {
         self.block_range_scanner =
             self.block_range_scanner.with_reorg_rewind_depth(reorg_rewind_depth);
-        self
-    }
-
-    /// Adjusts the retry interval when reconnecting to the provider.
-    #[must_use]
-    pub fn with_retry_interval(mut self, retry_interval: Duration) -> Self {
-        self.block_range_scanner = self.block_range_scanner.with_retry_interval(retry_interval);
         self
     }
 
@@ -168,7 +161,6 @@ impl<N: Network> EventScanner<N> {
                 continue;
             }
 
-            // TODO: configurable buffer size / smaller buffer ?
             let (sender, receiver) = mpsc::channel::<Log>(1024);
 
             let callback = filter.callback.clone();

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,7 +8,6 @@ use crate::callback::EventCallback;
 pub struct EventFilter {
     pub contract_address: Address,
     /// Human-readable event signature, e.g. "Transfer(address,address,uint256)".
-    /// TODO: Maybe change this to selector i.e. B256
     pub event: String,
     pub callback: Arc<dyn EventCallback + Send + Sync>,
 }


### PR DESCRIPTION
The `retry_interval` is not used (and most likely [won't be used](https://github.com/OpenZeppelin/Event-Scanner/issues/3#issuecomment-3306462057)) and should be re-introduced only when we see it's necessary.