### PR TITLE
Minor optimisations

### DIFF
--- a/src/block_range_scanner.rs
+++ b/src/block_range_scanner.rs
@@ -310,7 +310,7 @@ struct Service<N: Network> {
     config: Config,
     provider: RootProvider<N>,
     subscriber: Option<mpsc::Sender<BlockRangeMessage>>,
-    next_start_block: u64,
+    next_start_block: BlockNumber,
     websocket_connected: bool,
     processed_count: u64,
     error_count: u64,
@@ -553,8 +553,8 @@ impl<N: Network> Service<N> {
 
     async fn sync_historical_data(
         &mut self,
-        start: u64,
-        end: u64,
+        start: BlockNumber,
+        end: BlockNumber,
     ) -> Result<(), BlockRangeScannerError> {
         let mut batch_count = 0;
 


### PR DESCRIPTION
- Removed fetching block on each iteration of historical fetching, as end block as already been validated.
- Use join! where it make sense 
- Use ok_or_else for lazy evaluation of errors
- Removed block hash and number --> this led me to remove the rewind on reorg all together and im pretty sure it doesnt work so getting ready to deprecate it in favour of https://github.com/OpenZeppelin/Event-Scanner/pull/115
