### PR TITLE
Refactor `try_operation_with_failover` and Expose It and `CoreError` publicly from `RobustProvider`

### DIFF
--- a/src/robust_provider/provider.rs
+++ b/src/robust_provider/provider.rs
@@ -9,6 +9,7 @@ use alloy::{
     transports::{RpcError, TransportErrorKind},
 };
 use backon::{ExponentialBuilder, Retryable};
+use futures::TryFutureExt;
 use thiserror::Error;
 use tokio::time::{error as TokioError, timeout};
 use tracing::{error, info};
@@ -325,15 +326,11 @@ impl<N: Network> RobustProvider<N> {
         Fut: Future<Output = Result<T, RpcError<TransportErrorKind>>>,
     {
         let primary = self.primary();
-        let result = self.try_provider_with_timeout(primary, &operation).await;
-
-        if result.is_ok() {
-            return result;
-        }
-
-        let last_error = result.unwrap_err();
-
-        self.try_fallback_providers(&operation, require_pubsub, last_error).await
+        self.try_provider_with_timeout(primary, &operation)
+            .or_else(|last_error| {
+                self.try_fallback_providers(&operation, require_pubsub, last_error)
+            })
+            .await
     }
 
     pub(crate) async fn try_fallback_providers<T: Debug, F, Fut>(


### PR DESCRIPTION
Resolves #272 