### PR TITLE
Skip benches on dependabot PRs

### DIFF
--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   benchmark:
     name: "Continuous PR Benchmarking: ${{ matrix.suite }}"
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
Fixes issues like https://github.com/OpenZeppelin/Event-Scanner/actions/runs/21645000444/job/62455230062?pr=321

Event Scanner is not performance critical, so makes little sense in running benches on dependabot PRs.

Anyway, running benches on dependabot would require giving dependabot access to all bench-related secrets, which is a security concern that's not worth having.