### PR TITLE
fix(bench): regenerate anvil state dump and pin anvil version in CI

### DIFF
--- a/.github/workflows/base_benchmarks.yml
+++ b/.github/workflows/base_benchmarks.yml
@@ -42,6 +42,13 @@ jobs:
 
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
+        with:
+          # Pin to the anvil version used to generate benches/dumps/state_*.json.gz
+          # (see anvil_version in benches/dumps/state_*.metadata.json). Anvil's
+          # state-dump JSON is not version-compatible: loading a dump with a
+          # different version fails with SerializableTransactionType / missing
+          # field errors. Bump this together with the regenerated dump files.
+          version: v1.7.0
 
       - name: Setup Bencher
         # Official docs recommend using `main` commit, because discrepancies between CI version and Bencher's API version

--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -48,6 +48,13 @@ jobs:
 
       - name: Setup Foundry
         uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1.8.0
+        with:
+          # Pin to the anvil version used to generate benches/dumps/state_*.json.gz
+          # (see anvil_version in benches/dumps/state_*.metadata.json). Anvil's
+          # state-dump JSON is not version-compatible: loading a dump with a
+          # different version fails with SerializableTransactionType / missing
+          # field errors. Bump this together with the regenerated dump files.
+          version: v1.7.0
 
       - name: Setup Bencher
         # Official docs recommend using `main` commit, because discrepancies between CI version and Bencher's API version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ bench-utils = [
     "dep:flate2",
     "dep:tracing",
     "alloy/node-bindings",
-    "alloy/provider-ws",   # needed when running ./bin/generate_dump.rs
+    "alloy/provider-ws",   # needed when running `cargo run --bin generate_dump --features bench-utils`
 ]
 example = ["tracing", "dep:anyhow"]
 http-subscription = ["robust-provider/http-subscription"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,11 @@ flate2 = { version = "1.1", optional = true }
 tracing = { version = "0.1", optional = true }
 
 [dev-dependencies]
-alloy = { version = "1.1.2", features = ["node-bindings", "provider-ws", "rpc-types-anvil"] }
+alloy = { version = "1.1.2", features = [
+    "node-bindings",
+    "provider-ws",
+    "rpc-types-anvil",
+] }
 criterion = { version = "0.8", features = ["async_tokio", "html_reports"] }
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 test-log = { version = "0.2.18", features = ["trace"] }
@@ -108,6 +112,7 @@ bench-utils = [
     "dep:flate2",
     "dep:tracing",
     "alloy/node-bindings",
+    "alloy/provider-ws",   # needed when running ./bin/generate_dump.rs
 ]
 example = ["tracing", "dep:anyhow"]
 http-subscription = ["robust-provider/http-subscription"]

--- a/benches/dumps/state_100000.metadata.json
+++ b/benches/dumps/state_100000.metadata.json
@@ -1,7 +1,7 @@
 {
   "event_count": 100000,
   "contract_address": "0x5fbdb2315678afecb367f032d93f642f64180aa3",
-  "block_number": 3298,
-  "generation_time_secs": 32.816945,
-  "anvil_version": "anvil Version: 1.5.1-stable\nCommit SHA: b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2\nBuild Timestamp: 2025-12-22T11:41:09.812070000Z (1766403669)\nBuild Profile: maxperf"
+  "block_number": 28263,
+  "generation_time_secs": 282.780018286,
+  "anvil_version": "anvil Version: 1.6.0-v1.7.0\nCommit SHA: f83bad912a9dba7bf0371def1e70bb1896048356\nBuild Timestamp: 2026-04-28T14:07:10.568929921Z (1777385230)\nBuild Profile: dist"
 }


### PR DESCRIPTION
See [failing CIs]:
- https://github.com/OpenZeppelin/Event-Scanner/actions/runs/25166417746
- https://github.com/OpenZeppelin/Event-Scanner/actions/runs/25432787223
- https://github.com/OpenZeppelin/Event-Scanner/actions/runs/25796679579

The committed state_100000.json.gz dump was unloadable by every current anvil release (v1.5.1 errors on missing `index` in receipts, v1.7.0 and nightly error on SerializableTransactionType), breaking the PR and base benchmark workflows. Regenerate the dump with anvil v1.7.0 and pin the foundry-toolchain action to v1.7.0 in both workflows so the loader and the dump stay in lockstep — bumping anvil now requires regenerating the dump.

Also add `alloy/provider-ws` to the `bench-utils` feature so `cargo run --bin generate_dump --features bench-utils` can connect over websockets (dev-dependencies don't apply to `cargo run --bin`).

