### PR TITLE
docs: remove telegram contact link

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,7 +59,7 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement on [Telegram](t.me/openzeppelin_tg/2).
+reported to the community leaders responsible for enforcement by [contacting us](https://www.openzeppelin.com/contact).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,7 +59,8 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement by [contacting us](https://www.openzeppelin.com/contact).
+reported to the community leaders responsible for enforcement by
+[contacting us](https://www.openzeppelin.com/contact).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,8 +59,7 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement by
-[contacting us](https://www.openzeppelin.com/contact).
+reported to the community leaders responsible for enforcement by [contacting us](https://www.openzeppelin.com/contact).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
Replaces https://github.com/OpenZeppelin/Event-Scanner/pull/365, see [reason](https://github.com/OpenZeppelin/Event-Scanner/pull/365#issuecomment-5100316949)