### PR TITLE
ci: Update GitHub Actions workflow to remove paths-ignore

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,23 +5,9 @@ permissions:
 
 on:
   pull_request:
-    paths-ignore:
-      - "**.md"
-      - ".vscode"
-      - ".cargo"
-      - "benches/**"
-      - "examples/**"
-      - "src/bin/generate_dump.rs"
   merge_group:
   push:
     branches: [main, release-v*]
-    paths-ignore:
-      - "**.md"
-      - ".vscode"
-      - ".cargo"
-      - "benches/**"
-      - "examples/**"
-      - "src/bin/generate_dump.rs"
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Removed paths-ignore for pull_request and push events in the workflow configuration.

This is causing stuck PRs like https://github.com/OpenZeppelin/Event-Scanner/pull/366#pullrequestreview-4805107401 - these jobs are "Required" for a PR to be merged, but they never run because the PR changes ignored files.
