### PR TITLE
ci: Update check.yml workflow to remove paths-ignore

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,15 +13,8 @@ permissions:
 on:
   push:
     branches: [main, release-v*]
-    paths-ignore:
-      - "**.md"
-      - ".vscode"
-      - ".cargo"
   pull_request:
-    paths-ignore:
-      - "**.md"
-      - ".vscode"
-      - ".cargo"
+
 # If new code is pushed to a PR branch, then cancel in progress workflows for
 # that PR. Ensures that we don't waste CI time, and returns results quicker.
 # https://github.com/jonhoo/rust-ci-conf/pull/5


### PR DESCRIPTION
Removed paths-ignore for pull_request and push events in the workflow configuration.

This is causing stuck PRs like #366 (review) - these jobs are "Required" for a PR to be merged, but they never run because the PR changes ignored files.

Related https://github.com/OpenZeppelin/Event-Scanner/pull/367
